### PR TITLE
Sprite sorting func. fixing

### DIFF
--- a/srcs/raycast_rest.c
+++ b/srcs/raycast_rest.c
@@ -41,6 +41,7 @@ void				sort_sprites(t_window *window)
 	max = 0;
 	while (i < window->cub->sprite_count - 1)
 	{
+		max = i;
 		j = i + 1;
 		while (j < window->cub->sprite_count)
 		{


### PR DESCRIPTION
When two or more sprites in a row, backward one cover up another which is more closer to player. 
I fixed little thing..